### PR TITLE
Upgrade to NTS 2.0

### DIFF
--- a/src/NetTopologySuite.IO.VectorTiles.GeoJson/GeoJsonTileWriter.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.GeoJson/GeoJsonTileWriter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Text;
 using NetTopologySuite.Features;
 using Newtonsoft.Json;

--- a/src/NetTopologySuite.IO.VectorTiles.GeoJson/NetTopologySuite.IO.VectorTiles.GeoJson.csproj
+++ b/src/NetTopologySuite.IO.VectorTiles.GeoJson/NetTopologySuite.IO.VectorTiles.GeoJson.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="NetTopologySuite.IO.GeoJson" Version="1.15.5" />
+        <PackageReference Include="NetTopologySuite.IO.GeoJson" Version="2.0.2" />
     </ItemGroup>
     
 </Project>

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
@@ -1,8 +1,5 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
-using GeoAPI.Geometries;
 using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
 
@@ -161,13 +158,13 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         {
             const int CoordinateIndex = 0;
 
-            var geometry = (IGeometry) puntal;
+            var geometry = (Geometry) puntal;
             int currentX = 0, currentY = 0;
 
             var parameters = new List<uint>();
             for (int i = 0; i < geometry.NumGeometries; i++)
             {
-                var point = (IPoint) geometry.GetGeometryN(i);
+                var point = (Point) geometry.GetGeometryN(i);
                 var position = tgt.Transform(point.CoordinateSequence, CoordinateIndex, ref currentX, ref currentY);
                 if (i == 0 || position.x > 0 || position.y > 0)
                 {
@@ -185,11 +182,11 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
 
         private static IEnumerable<uint> Encode(ILineal lineal, TileGeometryTransform tgt)
         {
-            var geometry = (IGeometry)lineal;
+            var geometry = (Geometry)lineal;
             int currentX = 0, currentY = 0;
             for (int i = 0; i < geometry.NumGeometries; i++)
             {
-                var lineString = (ILineString)geometry.GetGeometryN(i);
+                var lineString = (LineString)geometry.GetGeometryN(i);
                 foreach (uint encoded in Encode(lineString.CoordinateSequence, tgt, ref currentX, ref currentY, false))
                     yield return encoded;
             }
@@ -197,11 +194,11 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
 
         private static IEnumerable<uint> Encode(IPolygonal polygonal, TileGeometryTransform tgt)
         {
-            var geometry = (IGeometry)polygonal;
+            var geometry = (Geometry)polygonal;
             int currentX = 0, currentY = 0;
             for (int i = 0; i < geometry.NumGeometries; i++)
             {
-                var polygon = (IPolygon)geometry.GetGeometryN(i);
+                var polygon = (Polygon)geometry.GetGeometryN(i);
                 if (polygon.Area == 0d)
                     continue;
 
@@ -215,7 +212,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             }
         }
 
-        private static IEnumerable<uint> Encode(ICoordinateSequence sequence, TileGeometryTransform tgt,
+        private static IEnumerable<uint> Encode(CoordinateSequence sequence, TileGeometryTransform tgt,
             ref int currentX, ref int currentY,
             bool ring = false, bool ccw = false)
         {

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/Tile.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/Tile.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace NetTopologySuite.IO.VectorTiles.Mapbox
 {
     [ProtoBuf.ProtoContract(Name = @"tile")]

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransform.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransform.cs
@@ -1,4 +1,5 @@
-using GeoAPI.Geometries;
+
+using NetTopologySuite.Geometries;
 
 namespace NetTopologySuite.IO.VectorTiles.Mapbox
 {
@@ -49,7 +50,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         /// <param name="currentX">The current horizontal component of the cursor location. This value is updated.</param>
         /// <param name="currentY">The current vertical component of the cursor location. This value is updated.</param>
         /// <returns>The position relative to the local point at (<paramref name="currentX"/>, <paramref name="currentY"/>).</returns>
-        public (int x, int y) Transform(ICoordinateSequence sequence, int index, ref int currentX, ref int currentY)
+        public (int x, int y) Transform(CoordinateSequence sequence, int index, ref int currentX, ref int currentY)
         {
             int localX = (int) ((sequence.GetOrdinate(index, Ordinate.X) - Left) / LongitudeStep);
             int localY = (int) ((Top - sequence.GetOrdinate(index, Ordinate.Y)) / LatitudeStep);

--- a/src/NetTopologySuite.IO.VectorTiles/NetTopologySuite.IO.VectorTiles.csproj
+++ b/src/NetTopologySuite.IO.VectorTiles/NetTopologySuite.IO.VectorTiles.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NetTopologySuite" Version="1.15.3" />
-    <PackageReference Include="NetTopologySuite.Features" Version="1.15.1" />
+    <PackageReference Include="NetTopologySuite" Version="2.0.0" />
+    <PackageReference Include="NetTopologySuite.Features" Version="2.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/NetTopologySuite.IO.VectorTiles/Tilers/LineStringTiler.cs
+++ b/src/NetTopologySuite.IO.VectorTiles/Tilers/LineStringTiler.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using GeoAPI.Geometries;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO.VectorTiles.Tiles;
 using NetTopologySuite.Operation.Overlay;
@@ -19,7 +17,7 @@ namespace NetTopologySuite.IO.VectorTiles.Tilers
         /// <param name="zoom">The zoom.</param>
         /// <returns>An enumerable of all tiles.</returns>
         /// <remarks>It's possible this returns too many tiles, it's up to the 'Cut' method to exactly decide what tiles a linestring belongs in.</remarks>
-        public static IEnumerable<ulong> Tiles(this ILineString lineString, int zoom)
+        public static IEnumerable<ulong> Tiles(this LineString lineString, int zoom)
         {
             // always return the tile of the first coordinate.
             var previousTileId = Tile.CreateAroundLocationId(lineString.Coordinates[0].Y, lineString.Coordinates[0].X, zoom);
@@ -76,7 +74,7 @@ namespace NetTopologySuite.IO.VectorTiles.Tilers
         /// <param name="tilePolygon">The tile polygon.</param>
         /// <param name="lineString">The linestring.</param>
         /// <returns>One or more segments.</returns>
-        public static IEnumerable<ILineString> Cut(this IPolygon tilePolygon, ILineString lineString)
+        public static IEnumerable<LineString> Cut(this Polygon tilePolygon, LineString lineString)
         {
             var op = new OverlayOp(lineString, tilePolygon);
             var intersection = op.GetResultGeometry(SpatialFunction.Intersection);
@@ -87,28 +85,28 @@ namespace NetTopologySuite.IO.VectorTiles.Tilers
 
             switch (intersection)
             {
-                case ILineString ls:
+                case LineString ls:
                     // intersection is a linestring.
                     yield return ls;
                     yield break;
                 
-                case IGeometryCollection gc:
+                case GeometryCollection gc:
                 {
                     foreach (var geometry in gc.Geometries)
                     {
                         switch (geometry)
                         {
-                            case ILineString ls0:
+                            case LineString ls0:
                                 yield return ls0;
                                 break;
-                            case IPoint _:
+                            case Point _:
                                 // The linestring only has a single point in this tile
                                 // We skip it
                                 // TODO check if this is correct
                                 continue;
                             default:
                                 throw new Exception(
-                                    $"{nameof(LineStringTiler)}.{nameof(Cut)} failed: A geometry was found in the intersection that wasn't a {nameof(ILineString)}.");
+                                    $"{nameof(LineStringTiler)}.{nameof(Cut)} failed: A geometry was found in the intersection that wasn't a {nameof(LineString)}.");
                         }
                     }
 

--- a/src/NetTopologySuite.IO.VectorTiles/Tilers/PointTiler.cs
+++ b/src/NetTopologySuite.IO.VectorTiles/Tilers/PointTiler.cs
@@ -1,6 +1,4 @@
-using GeoAPI.Geometries;
 using NetTopologySuite.Geometries;
-using NetTopologySuite.IO.VectorTiles.Tiles;
 
 namespace NetTopologySuite.IO.VectorTiles.Tilers
 {
@@ -12,7 +10,7 @@ namespace NetTopologySuite.IO.VectorTiles.Tilers
         /// <param name="point">The point.</param>
         /// <param name="zoom">The zoom.</param>
         /// <returns>The tile.</returns>
-        public static ulong Tile(this IPoint point, int zoom)
+        public static ulong Tile(this Point point, int zoom)
         {
             return Tiles.Tile.CreateAroundLocationId(point.Y, point.X, zoom);
         }

--- a/src/NetTopologySuite.IO.VectorTiles/Tilers/PolygonTiler.cs
+++ b/src/NetTopologySuite.IO.VectorTiles/Tilers/PolygonTiler.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using GeoAPI.Geometries;
+using NetTopologySuite.Geometries;
 using NetTopologySuite.IO.VectorTiles.Tiles;
 
 namespace NetTopologySuite.IO.VectorTiles.Tilers
@@ -14,7 +14,7 @@ namespace NetTopologySuite.IO.VectorTiles.Tilers
         /// <param name="zoom">The zoom.</param>
         /// <param name="margin">The margin for the tiles polygon (in %)</param>
         /// <returns>An enumerable of all tiles.</returns>
-        public static IEnumerable<(ulong, IPolygonal)> Tiles(IPolygon polygon, int zoom, int margin = 5)
+        public static IEnumerable<(ulong, IPolygonal)> Tiles(Polygon polygon, int zoom, int margin = 5)
         {
             // Get the envelope
             var envelope = polygon.EnvelopeInternal;

--- a/src/NetTopologySuite.IO.VectorTiles/Tiles/TileExtensions.cs
+++ b/src/NetTopologySuite.IO.VectorTiles/Tiles/TileExtensions.cs
@@ -1,15 +1,14 @@
-using GeoAPI.Geometries;
 using NetTopologySuite.Geometries;
 
 namespace NetTopologySuite.IO.VectorTiles.Tiles
 {
     internal static class TileExtensions
     {
-        private static IGeometryFactory _factory;
+        private static GeometryFactory _factory;
 
-        public static IGeometryFactory Factory
+        public static GeometryFactory Factory
         {
-            get => _factory ??= GeoAPI.GeometryServiceProvider.Instance.CreateGeometryFactory(new PrecisionModel(), 4326);
+            get => _factory ??= new GeometryFactory(new PrecisionModel(), 4326);
             set => _factory = value;
         }
 
@@ -19,7 +18,7 @@ namespace NetTopologySuite.IO.VectorTiles.Tiles
         /// <param name="tile">The tile.</param>
         /// <param name="margin">The margin (in %).</param>
         /// <returns>The polygon.</returns>
-        public static IPolygon ToPolygon(this Tile tile, int margin = 5)
+        public static Polygon ToPolygon(this Tile tile, int margin = 5)
         {
             float factor = margin / 100f;
             float xMar = System.Math.Abs((tile.Right - tile.Left) * factor);

--- a/test/NetTopologySuite.IO.VectorTiles.Tests.Functional/Program.cs
+++ b/test/NetTopologySuite.IO.VectorTiles.Tests.Functional/Program.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
-using NetTopologySuite.IO.VectorTiles.Tiles;
 
 namespace NetTopologySuite.IO.VectorTiles.Tests.Functional
 {

--- a/test/NetTopologySuite.IO.VectorTiles.Tests/NetTopologySuite.IO.VectorTiles.Tests.csproj
+++ b/test/NetTopologySuite.IO.VectorTiles.Tests/NetTopologySuite.IO.VectorTiles.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="1.15.5" />
+    <PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="2.0.2" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/test/NetTopologySuite.IO.VectorTiles.Tests/Tilers/LineStringTilerTests.cs
+++ b/test/NetTopologySuite.IO.VectorTiles.Tests/Tilers/LineStringTilerTests.cs
@@ -1,10 +1,5 @@
 using System;
 using System.Linq;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using GeoAPI.Geometries;
-using Microsoft.VisualStudio.TestPlatform.Utilities;
-using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO.VectorTiles.Tilers;
 using NetTopologySuite.IO.VectorTiles.Tiles;

--- a/test/NetTopologySuite.IO.VectorTiles.Tests/Tilers/PolygonTilerTest.cs
+++ b/test/NetTopologySuite.IO.VectorTiles.Tests/Tilers/PolygonTilerTest.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
-using GeoAPI.Geometries;
+using NetTopologySuite.Geometries;
 using NetTopologySuite.IO.VectorTiles.Tilers;
 using NetTopologySuite.IO.VectorTiles.Tiles;
 using Xunit;
@@ -19,7 +19,7 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
         [Fact]
         public void TestAurichAtZoom12()
         {
-            var p = (IPolygon) new WKTReader().Read(
+            var p = (Polygon) new WKTReader().Read(
                 @"POLYGON((7.66002273417368 53.542572993953, 7.66173766036759 53.5391581883133, 7.66214163494917 53.5373509789836, " +
                  "7.66261436546659 53.5363456891095, 7.66258258916752 53.5359043208466, 7.65946163788716 53.5361457486512, " +
                  "7.65881558902363 53.5361308714676, 7.65810608331794 53.5359860470069, 7.65747761962654 53.5357003268469, " +
@@ -98,12 +98,12 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
                  "7.63264843632057 53.5617107926166, 7.64793910227671 53.5616450951347, 7.6492258209762 53.5613690742985, " +
                  "7.6504454266148 53.560731792846, 7.65610572328535 53.5505918455274, 7.66002273417368 53.542572993953))");
 
-            var lst = new List<IGeometry>();
-            var lst2 = new List<IGeometry>();
-            var lst3 = new List<IGeometry>();
+            var lst = new List<Geometry>();
+            var lst2 = new List<Geometry>();
+            var lst3 = new List<Geometry>();
             foreach (var valueTuple in PolygonTiler.Tiles(p, 12))
             {
-                var geom = (IGeometry) valueTuple.Item2;
+                var geom = (Geometry) valueTuple.Item2;
                 for (var i = 0; i < geom.NumGeometries; i ++)
                     lst.Add(geom.GetGeometryN(i));
 
@@ -136,9 +136,9 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
             var at = new Geometries.Utilities.AffineTransformation(
                 1d, 0d, 0.5d * p.EnvelopeInternal.Width, 
                 0d, 1d, 0.5d * p.EnvelopeInternal.Height);
-            p = (IPolygon)at.Transform(p);
+            p = (Polygon)at.Transform(p);
 
-            var tiles = PolygonTiler.Tiles(p, 4, 0).Select(itm => (IGeometry)itm.Item2).ToList();
+            var tiles = PolygonTiler.Tiles(p, 4, 0).Select(itm => (Geometry)itm.Item2).ToList();
 
             Assert.Equal(4, tiles.Count);
             Assert.True(System.Math.Abs(p.Area - tiles.Sum(itm => itm.Area)) <= 0.00001);
@@ -150,7 +150,7 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
             var t = new Tile(5, 12, 4);
             var p = t.ToPolygon(1);
 
-            var tiles = PolygonTiler.Tiles(p, 4, 0).Select(itm => (IGeometry)itm.Item2).ToList();
+            var tiles = PolygonTiler.Tiles(p, 4, 0).Select(itm => (Geometry)itm.Item2).ToList();
 
             Assert.Equal(9, tiles.Count);
             Assert.True(t.ToPolygon(0).EqualsTopologically(tiles[4]));
@@ -163,9 +163,9 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
             var t = new Tile(5, 12, 4);
             var p = t.ToPolygon(1);
             var at = Geometries.Utilities.AffineTransformation.RotationInstance(System.Math.PI * 0.01);
-            p = (IPolygon)at.Transform(p);
+            p = (Polygon)at.Transform(p);
             
-            var tiles = PolygonTiler.Tiles(p, 4, 0).Select(itm => (IGeometry)itm.Item2).ToList();
+            var tiles = PolygonTiler.Tiles(p, 4, 0).Select(itm => (Geometry)itm.Item2).ToList();
 
             Assert.Equal(4, tiles.Count);
             Assert.True(System.Math.Abs(p.Area - tiles.Sum(itm => itm.Area)) <= 0.00001);


### PR DESCRIPTION
Related to issue #9.
Upgraded code to use NTS 2.x.
Mainly removed interfaces and switched to concrete, removed GeoAPI usages.
I have used `new GeometryFactory()` I hope this is OK.
I have removed the `IdAttributeName` from roundtrip base as I couldn't find an alternative, feel free to change this.
All tests pass from what I checked.