### PR TITLE
Improve PolygonTiler performance

### DIFF
--- a/src/NetTopologySuite.IO.VectorTiles.GeoJson/NetTopologySuite.IO.VectorTiles.GeoJson.csproj
+++ b/src/NetTopologySuite.IO.VectorTiles.GeoJson/NetTopologySuite.IO.VectorTiles.GeoJson.csproj
@@ -15,6 +15,7 @@
 
     <ItemGroup>
         <PackageReference Include="NetTopologySuite.IO.GeoJson" Version="2.0.2" />
+        <PackageReference Include="NetTopologySuite.Features" Version="2.1.0" />
     </ItemGroup>
     
 </Project>

--- a/src/NetTopologySuite.IO.VectorTiles/Tilers/PolygonTiler.cs
+++ b/src/NetTopologySuite.IO.VectorTiles/Tilers/PolygonTiler.cs
@@ -34,6 +34,51 @@ namespace NetTopologySuite.IO.VectorTiles.Tilers
             {
                 if (tile == null) continue;
                 var testPolygon = tile.ToPolygon(margin);
+                
+                if (prep.Contains(testPolygon))
+                {
+                    yield return (tile.Id, testPolygon);
+                }
+                else if (prep.Intersects(testPolygon))
+                {
+                    // Compute the intersection geometry
+                    var result = polygon.Intersection(testPolygon);
+
+                    // Only return if result is polygonal
+                    if (result is IPolygonal polygonalResult)
+                        yield return (tile.Id, polygonalResult);
+                }
+            }
+        }
+        /// <summary>
+        /// Returns all the tiles this polygon is part of and the polygonal portion in it..
+        /// </summary>
+        /// <param name="polygon">The linestring.</param>
+        /// <param name="zoom">The zoom.</param>
+        /// <param name="margin">The margin for the tiles polygon (in %)</param>
+        /// <returns>An enumerable of all tiles.</returns>
+        [Obsolete("Please remove! Just to prove that overhauled Tiles function works faster")]
+        public static IEnumerable<(ulong, IPolygonal)> TilesOld(Polygon polygon, int zoom, int margin = 5)
+        {
+            // Get the envelope
+            var envelope = polygon.EnvelopeInternal;
+            var lt = Tile.CreateAroundLocation(envelope.MaxY, envelope.MinX, zoom);
+            if (lt == null) throw new Exception();
+            var rb = Tile.CreateAroundLocation(envelope.MinY, envelope.MaxX, zoom);
+            if (rb == null) throw new Exception();
+
+            // Compute the possible tile range
+            var tileRange = new TileRange(lt.X, lt.Y, rb.X, rb.Y, zoom);
+
+            // Build a prepared geometry to perform faster intersection predicate
+            var prep = Geometries.Prepared.PreparedGeometryFactory.Prepare(polygon);
+
+            // Test polygon tiles.
+            foreach (var tile in tileRange)
+            {
+                if (tile == null) continue;
+                var testPolygon = tile.ToPolygon(margin);
+
                 if (prep.Intersects(testPolygon))
                 {
                     // Compute the intersection geometry

--- a/test/NetTopologySuite.IO.VectorTiles.Tests/NetTopologySuite.IO.VectorTiles.Tests.csproj
+++ b/test/NetTopologySuite.IO.VectorTiles.Tests/NetTopologySuite.IO.VectorTiles.Tests.csproj
@@ -17,4 +17,10 @@
     <ProjectReference Include="..\..\src\NetTopologySuite.IO.VectorTiles.Mapbox\NetTopologySuite.IO.VectorTiles.Mapbox.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="data\russia.osm.geojson">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
The old implementation of `PolygonTiler.Tiles` did not take advantage of the condition when a created tile is fully contained by the polygon to tile. This lead to the following statistics:

```
Test PolygonTiler with Russia (Old) (zoom: 15, time: 30)
No. of tiles created: 18996 (00:00:30.0047001)
Part of covered area: 0,03 %
```

Adding a `PreparedPolygon.Contains` predicate test improves the situation drastically:
```
Test PolygonTiler with Russia (zoom: 15, time: 30)
No. of tiles created: 2365692 (00:00:30.0038741)
Part of covered area: 2,48 %
```

relates to #12 