### PR TITLE
.net5.0, Removes the use of Newtonsoft.Json in favor of System.Text.J…

### DIFF
--- a/src/NetTopologySuite.IO.VectorTiles.GeoJson/GeoJsonTileWriter.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.GeoJson/GeoJsonTileWriter.cs
@@ -1,15 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using NetTopologySuite.Features;
-using Newtonsoft.Json;
 
 namespace NetTopologySuite.IO.VectorTiles.GeoJson
 {
     public static class GeoJsonTileWriter
     {
-        private static readonly JsonSerializer Serializer = GeoJsonSerializer.Create();
-        
         /// <summary>
         /// Writes the tiles in a /z/x/y-{layer}.geojson folder structure.
         /// </summary>
@@ -81,9 +77,7 @@ namespace NetTopologySuite.IO.VectorTiles.GeoJson
 
             if (featureCollection.Count == 0) return;
 
-            var streamWriter = new StreamWriter(stream, Encoding.Default, 1024, true);
-            Serializer.Serialize(streamWriter, featureCollection);
-            streamWriter.Flush();
+            System.Text.Json.JsonSerializer.Serialize(new System.Text.Json.Utf8JsonWriter(stream), featureCollection);
         }
         
         /// <summary>
@@ -101,9 +95,7 @@ namespace NetTopologySuite.IO.VectorTiles.GeoJson
 
             if (featureCollection.Count == 0) return;
 
-            var streamWriter = new StreamWriter(stream, Encoding.Default, 1024, true);
-            Serializer.Serialize(streamWriter, featureCollection);
-            streamWriter.Flush();
+            System.Text.Json.JsonSerializer.Serialize(new System.Text.Json.Utf8JsonWriter(stream), featureCollection);
         }
     }
 }

--- a/src/NetTopologySuite.IO.VectorTiles.GeoJson/NetTopologySuite.IO.VectorTiles.GeoJson.csproj
+++ b/src/NetTopologySuite.IO.VectorTiles.GeoJson/NetTopologySuite.IO.VectorTiles.GeoJson.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>net5.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <PackageVersion>0.0.15</PackageVersion>
         <Title>NetTopologySuite.IO.VectorTiles.GeoJson</Title>
@@ -10,11 +10,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\NetTopologySuite.IO.VectorTiles\NetTopologySuite.IO.VectorTiles.csproj" />
+      <PackageReference Include="NetTopologySuite.IO.GeoJSON4STJ" Version="2.1.1" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="NetTopologySuite.IO.GeoJson" Version="2.0.2" />
+      <ProjectReference Include="..\NetTopologySuite.IO.VectorTiles\NetTopologySuite.IO.VectorTiles.csproj" />
     </ItemGroup>
     
 </Project>

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/NetTopologySuite.IO.VectorTiles.Mapbox.csproj
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/NetTopologySuite.IO.VectorTiles.Mapbox.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>8</LangVersion>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
     <Nullable>disable</Nullable>
-    <PackageVersion>0.0.15</PackageVersion>
+    <PackageVersion>0.0.17</PackageVersion>
     <Title>NetTopologySuite.IO.VectorTiles.Mapbox</Title>
     <Authors>ANYWAYS BV</Authors>
     <PackageLicenseUrl>https://raw.githubusercontent.com/anyways-open/NetTopologySuite.IO.VectorTiles/master/LICENSE.md</PackageLicenseUrl>
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="protobuf-net" Version="2.4.0" />
+    <PackageReference Include="protobuf-net" Version="3.0.73" />
   </ItemGroup>
 
 </Project>

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/Tile.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/Tile.cs
@@ -214,16 +214,16 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         public enum GeomType
         {
 
-            [ProtoBuf.ProtoEnum(Name = @"Unknown", Value = 0)]
+            [ProtoBuf.ProtoEnum(Name = @"Unknown")]
             Unknown = 0,
 
-            [ProtoBuf.ProtoEnum(Name = @"Point", Value = 1)]
+            [ProtoBuf.ProtoEnum(Name = @"Point")]
             Point = 1,
 
-            [ProtoBuf.ProtoEnum(Name = @"LineString", Value = 2)]
+            [ProtoBuf.ProtoEnum(Name = @"LineString")]
             LineString = 2,
 
-            [ProtoBuf.ProtoEnum(Name = @"Polygon", Value = 3)]
+            [ProtoBuf.ProtoEnum(Name = @"Polygon")]
             Polygon = 3
         }
 

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransform.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransform.cs
@@ -28,8 +28,8 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             
             var meters = WebMercatorHandler.LatLonToMeters(_tile.Top, _tile.Left);
             var pixels = WebMercatorHandler.MetersToPixels(meters, tile.Zoom, (int) extent);
-            _top = (long)pixels.y;
-            _left = (long)pixels.x;
+            _top = (long)pixels.Y;
+            _left = (long)pixels.X;
         }
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         /// <param name="currentX">The current horizontal component of the cursor location. This value is updated.</param>
         /// <param name="currentY">The current vertical component of the cursor location. This value is updated.</param>
         /// <returns>The position relative to the local point at (<paramref name="currentX"/>, <paramref name="currentY"/>).</returns>
-        public (int x, int y) Transform(CoordinateSequence sequence, int index, ref int currentX, ref int currentY)
+        public System.Numerics.Vector2 Transform(CoordinateSequence sequence, int index, ref int currentX, ref int currentY)
         {
             var lon = sequence.GetOrdinate(index, Ordinate.X);
             var lat = sequence.GetOrdinate(index, Ordinate.Y);
@@ -49,22 +49,19 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             var meters = WebMercatorHandler.LatLonToMeters(lat, lon);
             var pixels = WebMercatorHandler.MetersToPixels(meters, _tile.Zoom, (int) _extent);
             
-            int localX = (int) (pixels.x - _left);
-            int localY = (int) (_top - pixels.y);
+            int localX = (int) (pixels.X - _left);
+            int localY = (int) (_top - pixels.Y);
             int dx = localX - currentX;
             int dy = localY - currentY;
             currentX = localX;
             currentY = localY;
 
-            return (dx, dy);
+            return new(dx, dy);
         }
 
-        public (double longitude, double latitude) TransformInverse(int x, int y)
+        public System.Numerics.Vector2 TransformInverse(System.Numerics.Vector2 v)
         {
-            var globalX = _left + x;
-            var globalY = _top - y;
-
-            var meters = WebMercatorHandler.PixelsToMeters((globalX, globalY), _tile.Zoom, (int) _extent);
+            var meters = WebMercatorHandler.PixelsToMeters(new (_left + v.X, _top - v.Y), _tile.Zoom, (int) _extent);
             var coordinates = WebMercatorHandler.MetersToLatLon(meters);
             return coordinates;
         }

--- a/src/NetTopologySuite.IO.VectorTiles/NetTopologySuite.IO.VectorTiles.csproj
+++ b/src/NetTopologySuite.IO.VectorTiles/NetTopologySuite.IO.VectorTiles.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>8</LangVersion>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <PackageVersion>0.0.15</PackageVersion>
     <Title>NetTopologySuite.IO.VectorTiles</Title>
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NetTopologySuite" Version="2.0.0" />
+    <PackageReference Include="NetTopologySuite" Version="2.1.0" />
     <PackageReference Include="NetTopologySuite.Features" Version="2.1.0" />
   </ItemGroup>
 

--- a/src/NetTopologySuite.IO.VectorTiles/Tilers/LineStringTiler.cs
+++ b/src/NetTopologySuite.IO.VectorTiles/Tilers/LineStringTiler.cs
@@ -25,7 +25,7 @@ namespace NetTopologySuite.IO.VectorTiles.Tilers
             
             // return all the next tiles.
             HashSet<ulong> tiles = null;
-            for (var c = 1; c < lineString.Coordinates.Length; c++)
+            for (var c = 1; c < lineString.Coordinates.Length; ++c)
             {
                 var coordinate = lineString.Coordinates[c];
                 var tileId = Tile.CreateAroundLocationId(coordinate.Y, coordinate.X, zoom);
@@ -43,15 +43,14 @@ namespace NetTopologySuite.IO.VectorTiles.Tilers
                     // determine all tiles between the two.
                     var previousCoordinate = lineString.Coordinates[c - 1];
                     var previousTile = new Tile(previousTileId);
-                    var previousTileCoordinates =
-                        previousTile.SubCoordinates(previousCoordinate.Y, previousCoordinate.X);
+                    var previousTileCoordinates = previousTile.SubCoordinates(previousCoordinate.Y, previousCoordinate.X);
                     var nextTile = new Tile(tileId);
                     var nextTileCoordinates = nextTile.SubCoordinates(coordinate.Y, coordinate.X);
 
-                    foreach (var (x, y) in Shared.LineBetween(previousTileCoordinates.x, previousTileCoordinates.y,
-                        nextTileCoordinates.x, nextTileCoordinates.y))
+                    foreach (var position in Shared.LineBetween(previousTileCoordinates.X, previousTileCoordinates.Y,
+                        nextTileCoordinates.X, nextTileCoordinates.Y))
                     {
-                        var betweenTileId = Tile.CalculateTileId(zoom, x, y);
+                        var betweenTileId = Tile.CalculateTileId(zoom, position);
                         if (tiles.Contains(betweenTileId)) continue;
                         tiles.Add(betweenTileId);
                         yield return betweenTileId;
@@ -85,6 +84,8 @@ namespace NetTopologySuite.IO.VectorTiles.Tilers
 
             switch (intersection)
             {
+                case Point _:
+                    yield break;
                 case LineString ls:
                     // intersection is a linestring.
                     yield return ls;

--- a/src/NetTopologySuite.IO.VectorTiles/Tilers/Shared.cs
+++ b/src/NetTopologySuite.IO.VectorTiles/Tilers/Shared.cs
@@ -15,7 +15,7 @@ namespace NetTopologySuite.IO.VectorTiles.Tilers
         /// <param name="x2">The x coordinate of the end of the line.</param>
         /// <param name="y2">The y coordinate of the end of the line.</param>
         /// <returns>The tiles that form the line between the two given coordinate pairs.</returns>
-        internal static IEnumerable<(int x, int y)> LineBetween(double x1, double y1, double x2, double y2)
+        internal static IEnumerable<System.Numerics.Vector2> LineBetween(double x1, double y1, double x2, double y2)
         {
             var xDiff = x2 - x1;
             var yDiff = y2 - y1;
@@ -30,16 +30,16 @@ namespace NetTopologySuite.IO.VectorTiles.Tilers
                 var xLast = (int) Math.Floor(x2);
                 var yLast = (int) Math.Floor(y2);
                 
-                var slope = (yDiff / xDiff);
+                var slope = yDiff / xDiff;
                 var y0 = y1 - (slope * x1);
                 
                 // with an increment of 1 we calculate y.
-                var right = (xDiff > 0);
-                // var up = (yDiff > 0);
+                var right = xDiff > 0;
+                // var up = yDiff > 0;
                 var xStep = right ? 1 : -1;
                 var start = right ? (int)Math.Ceiling(x1) : (int)Math.Floor(x1);
                 var end = right ? (int)Math.Floor(x2) : (int)Math.Ceiling(x2);
-                yield return (xPrevious, yPrevious);
+                yield return new(xPrevious, yPrevious);
                 for (var x = start; x != end + xStep; x += xStep)
                 {
                     // REMARK: this can be more efficient but this way numerically more stable. 
@@ -55,20 +55,20 @@ namespace NetTopologySuite.IO.VectorTiles.Tilers
                         // if we go left, we return the previous y at the same x.
                         if (right)
                         {
-                            yield return (xPrevious, yRounded);
+                            yield return new(xPrevious, yRounded);
                         }
                         else if(xPrevious != x)
                         {
-                            yield return (x, yPrevious);
+                            yield return new(x, yPrevious);
                         }
 
-                        yield return (x, yRounded);
+                        yield return new(x, yRounded);
                         xPrevious = x;
                         yPrevious = yRounded;
                     }
                     else if (xPrevious != x)
                     {
-                        yield return (x, yRounded);
+                        yield return new(x, yRounded);
                         xPrevious = x;
                         yPrevious = yRounded;
                     }
@@ -83,18 +83,18 @@ namespace NetTopologySuite.IO.VectorTiles.Tilers
                         // if we go left, we return the previous y at the same x.
                         if (xPrevious != xLast)
                         {
-                            yield return (xLast, yPrevious);
+                            yield return new (xLast, yPrevious);
                         }
                     }
 
-                    yield return (xLast, yLast);
+                    yield return new (xLast, yLast);
                 }
             }
             else
             { // we take y.
                 foreach (var reversed in LineBetween(y1, x1, y2, x2))
                 {
-                    yield return (reversed.y, reversed.x);
+                    yield return new (reversed.Y, reversed.X);
                 }
             }
         }

--- a/src/NetTopologySuite.IO.VectorTiles/Tiles/TileMath.cs
+++ b/src/NetTopologySuite.IO.VectorTiles/Tiles/TileMath.cs
@@ -1,0 +1,12 @@
+﻿namespace NetTopologySuite.IO.VectorTiles.Tiles
+{
+    internal static class TileMath
+    {
+        internal const int EarthRadius = 6378137;
+        internal const double PI2 = System.Math.PI * 2;
+        internal const double OriginShift = PI2 * EarthRadius / 2;
+        internal const double PI2EarthRadius = PI2 * EarthRadius;
+        internal const double OneRadian = 180.0 / System.Math.PI;
+        internal const double OneDegree = System.Math.PI / 180.0;
+    }
+}

--- a/src/NetTopologySuite.IO.VectorTiles/Tiles/WebMercator/WebMercatorHandler.cs
+++ b/src/NetTopologySuite.IO.VectorTiles/Tiles/WebMercator/WebMercatorHandler.cs
@@ -6,54 +6,45 @@ namespace NetTopologySuite.IO.VectorTiles.Tiles.WebMercator
     {
         // https://gist.github.com/nagasudhirpulla/9b5a192ccaca3c5992e5d4af0d1e6dc4
         
-        private const int EarthRadius = 6378137;
-        private const double OriginShift = 2 * Math.PI * EarthRadius / 2;
-        
         //Converts given lat/lon in WGS84 Datum to XY in Spherical Mercator EPSG:900913
-        public static (double x, double y) LatLonToMeters(double lat, double lon)
+        public static System.Numerics.Vector2 LatLonToMeters(double lat, double lon)
         {
-            var x = lon * OriginShift / 180;
+            var x = lon * TileMath.OriginShift / 180;
             var y = Math.Log(Math.Tan((90 + lat) * Math.PI / 360)) / (Math.PI / 180);
-            y = y * OriginShift / 180;
-            return (x, y);
+            y = y * TileMath.OriginShift / 180;
+            return new System.Numerics.Vector2((float)x, (float)y);
         }
         
         //Converts XY point from (Spherical) Web Mercator EPSG:3785 (unofficially EPSG:900913) to lat/lon in WGS84 Datum
-        public static (double x, double y) MetersToLatLon((double x, double y) m)
+        public static System.Numerics.Vector2 MetersToLatLon(System.Numerics.Vector2 m)
         {
-            var x = (m.x / OriginShift) * 180;
-            var y = (m.y / OriginShift) * 180;
+            var x = m.X / TileMath.OriginShift * 180;
+            var y = m.Y / TileMath.OriginShift * 180;
             y = 180 / Math.PI * (2 * Math.Atan(Math.Exp(y * Math.PI / 180)) - Math.PI / 2);
-            return (x, y);
+            return new System.Numerics.Vector2((float)x, (float)y);
         }
         
         //Converts EPSG:900913 to pyramid pixel coordinates in given zoom level
-        public static (double x, double y) MetersToPixels((double x, double y) m, int zoom, int tileSize)
+        public static System.Numerics.Vector2 MetersToPixels(System.Numerics.Vector2 m, int zoom, int tileSize)
         {
             var res = Resolution(zoom, tileSize);
-            var x = (m.x + OriginShift) / res;
-            var y = (m.y + OriginShift) / res;
-            return (x, y);
+            var x = (m.X + TileMath.OriginShift) / res;
+            var y = (m.Y + TileMath.OriginShift) / res;
+            return new System.Numerics.Vector2((float)x, (float)y);
         }
         
         //Converts pixel coordinates in given zoom level of pyramid to EPSG:900913
-        public static (double x, double y) PixelsToMeters((double x, double y) p, int zoom, int tileSize)
+        public static System.Numerics.Vector2 PixelsToMeters(System.Numerics.Vector2 p, int zoom, int tileSize)
         {
             var res = Resolution(zoom, tileSize);
-            var x = p.x * res - OriginShift;
-            var y = p.y * res - OriginShift;
-            return (x, y);
+            var x = p.X * res - TileMath.OriginShift;
+            var y = p.Y * res - TileMath.OriginShift;
+            return new System.Numerics.Vector2((float)x, (float)y);
         }
         
         //Resolution (meters/pixel) for given zoom level (measured at Equator)
-        public static double Resolution(int zoom, int tileSize)
-        {
-            return InitialResolution(tileSize) / (Math.Pow(2, zoom));
-        }
+        public static double Resolution(int zoom, int tileSize)=> InitialResolution(tileSize) / Math.Pow(2, zoom);
 
-        public static double InitialResolution(int tileSize)
-        {
-            return  2 * Math.PI * EarthRadius / tileSize;
-        }
+       public static double InitialResolution(int tileSize)=> TileMath.PI2EarthRadius / tileSize;
     }
 }

--- a/src/NetTopologySuite.IO.VectorTiles/VectorTileTree.cs
+++ b/src/NetTopologySuite.IO.VectorTiles/VectorTileTree.cs
@@ -6,9 +6,14 @@ namespace NetTopologySuite.IO.VectorTiles
     /// <summary>
     /// A vector tile tree.
     /// </summary>
-    public class VectorTileTree : IEnumerable<ulong>
+    public class VectorTileTree : IEnumerable<ulong>, IEnumerable<VectorTile>
     {
-        private readonly Dictionary<ulong, VectorTile> _tiles = new Dictionary<ulong, VectorTile>();
+        private readonly IDictionary<ulong, VectorTile> _tiles = new Dictionary<ulong, VectorTile>();
+
+        /// <summary>
+        /// All contained <see cref="VectorTiles"/>
+        /// </summary>
+        public IEnumerable<VectorTile> Tiles => _tiles.Values;
 
         /// <summary>
         /// Tries to get the given tile.
@@ -16,25 +21,27 @@ namespace NetTopologySuite.IO.VectorTiles
         /// <param name="tileId">The tile id.</param>
         /// <param name="vectorTile">The resulting tile (if any).</param>
         /// <returns>True if the tile exists.</returns>
-        public bool TryGet(ulong tileId, out VectorTile vectorTile)
-        {
-            return _tiles.TryGetValue(tileId, out vectorTile);
-        }
+        public bool TryGet(ulong tileId, out VectorTile vectorTile)=> _tiles.TryGetValue(tileId, out vectorTile);
 
+        /// <summary>
+        /// Gets a <see cref="VectorTile"/> by id
+        /// </summary>
+        /// <param name="tileId"></param>
+        /// <returns></returns>
         public VectorTile this[ulong tileId]
         {
             get => _tiles[tileId];
             set => _tiles[tileId] = value;
         }
 
-        public IEnumerator<ulong> GetEnumerator()
-        {
-            return _tiles.Keys.GetEnumerator();
-        }
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerator<ulong> GetEnumerator()=> _tiles.Keys.GetEnumerator();
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        IEnumerator<VectorTile> IEnumerable<VectorTile>.GetEnumerator()=> Tiles.GetEnumerator();
     }
 }

--- a/test/NetTopologySuite.IO.VectorTiles.Tests.Functional/NetTopologySuite.IO.VectorTiles.Tests.Functional.csproj
+++ b/test/NetTopologySuite.IO.VectorTiles.Tests.Functional/NetTopologySuite.IO.VectorTiles.Tests.Functional.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-    <LangVersion>8</LangVersion>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/test/NetTopologySuite.IO.VectorTiles.Tests.Functional/Program.cs
+++ b/test/NetTopologySuite.IO.VectorTiles.Tests.Functional/Program.cs
@@ -7,32 +7,37 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Functional
 {
     class Program
     {
+        static IEnumerable<(IFeature feature, int zoom, string layerName)> ConfigureFeature(IFeature feature)
+        {
+            for (var z = 12; z <= 14; ++z)
+            {
+                if (feature.Geometry is LineString)
+                {
+                    yield return (feature, z, "cyclenetwork");
+                }
+                else if (feature.Geometry is Polygon)
+                {
+                    yield return (feature, z, "polygons");
+                }
+                else
+                {
+                    yield return (feature, z, "cyclenodes");
+                }
+            }
+        }
+
         static void Main(string[] args)
         {
-            var features = (new GeoJsonReader()).Read<FeatureCollection>(File.ReadAllText("test.geojson"));
+            var JsonSerializerOptions = new System.Text.Json.JsonSerializerOptions();
+
+            JsonSerializerOptions.Converters.Add(new NetTopologySuite.IO.Converters.GeoJsonConverterFactory());
+
+            var features = System.Text.Json.JsonSerializer.Deserialize<FeatureCollection>(File.ReadAllText("test.geojson"), JsonSerializerOptions);
 
             // build the vector tile tree.
             var tree = new VectorTileTree();
-            tree.Add(features, ConfigureFeature);
 
-            IEnumerable<(IFeature feature, int zoom, string layerName)> ConfigureFeature(IFeature feature)
-            {
-                for (var z = 12; z <= 14; z++)
-                {
-                    if (feature.Geometry is LineString)
-                    {
-                        yield return (feature, z, "cyclenetwork");
-                    }
-                    else if (feature.Geometry is Polygon)
-                    {
-                        yield return (feature, z, "polygons");
-                    }
-                    else
-                    {
-                        yield return (feature, z, "cyclenodes");
-                    }
-                }
-            }
+            foreach (var feature in features!) tree.Add(ConfigureFeature(feature));
 
             // write the tiles to disk as mvt.
             Mapbox.MapboxTileWriter.Write(tree, "tiles");

--- a/test/NetTopologySuite.IO.VectorTiles.Tests/NetTopologySuite.IO.VectorTiles.Tests.csproj
+++ b/test/NetTopologySuite.IO.VectorTiles.Tests/NetTopologySuite.IO.VectorTiles.Tests.csproj
@@ -1,16 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="2.0.2" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="2.0.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NetTopologySuite.IO.VectorTiles.Tests/Tilers/SharedTests.cs
+++ b/test/NetTopologySuite.IO.VectorTiles.Tests/Tilers/SharedTests.cs
@@ -12,10 +12,10 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
             var tiles = Shared.LineBetween(0.1, 0.5, 1.5, 0.9).ToList();
             
             Assert.Equal(2, tiles.Count);
-            Assert.Equal(0, tiles[0].x);
-            Assert.Equal(0, tiles[0].y);
-            Assert.Equal(1, tiles[1].x);
-            Assert.Equal(0, tiles[1].y);
+            Assert.Equal(0, tiles[0].X);
+            Assert.Equal(0, tiles[0].Y);
+            Assert.Equal(1, tiles[1].X);
+            Assert.Equal(0, tiles[1].Y);
         }
         
         [Fact]
@@ -24,10 +24,10 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
             var tiles = Shared.LineBetween(1.5, 0.5, 0.1, 0.9).ToList();
             
             Assert.Equal(2, tiles.Count);
-            Assert.Equal(1, tiles[0].x);
-            Assert.Equal(0, tiles[0].y);
-            Assert.Equal(0, tiles[1].x);
-            Assert.Equal(0, tiles[1].y);
+            Assert.Equal(1, tiles[0].X);
+            Assert.Equal(0, tiles[0].Y);
+            Assert.Equal(0, tiles[1].X);
+            Assert.Equal(0, tiles[1].Y);
         }
         
         [Fact]
@@ -36,10 +36,10 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
             var tiles = Shared.LineBetween(0.5, 0.1, 0.9, 1.5).ToList();
             
             Assert.Equal(2, tiles.Count);
-            Assert.Equal(0, tiles[0].x);
-            Assert.Equal(0, tiles[0].y);
-            Assert.Equal(0, tiles[1].x);
-            Assert.Equal(1, tiles[1].y);
+            Assert.Equal(0, tiles[0].X);
+            Assert.Equal(0, tiles[0].Y);
+            Assert.Equal(0, tiles[1].X);
+            Assert.Equal(1, tiles[1].Y);
         }
         
         [Fact]
@@ -48,10 +48,10 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
             var tiles = Shared.LineBetween(0.5,1.5,0.9,0.1).ToList();
             
             Assert.Equal(2, tiles.Count);
-            Assert.Equal(0, tiles[0].x);
-            Assert.Equal(1, tiles[0].y);
-            Assert.Equal(0, tiles[1].x);
-            Assert.Equal(0, tiles[1].y);
+            Assert.Equal(0, tiles[0].X);
+            Assert.Equal(1, tiles[0].Y);
+            Assert.Equal(0, tiles[1].X);
+            Assert.Equal(0, tiles[1].Y);
         }
         
         [Fact]
@@ -60,12 +60,12 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
             var tiles = Shared.LineBetween(0.9, 0.5, 1.9, 1.1).ToList();
             
             Assert.Equal(3, tiles.Count);
-            Assert.Equal(0, tiles[0].x);
-            Assert.Equal(0, tiles[0].y);
-            Assert.Equal(1, tiles[1].x);
-            Assert.Equal(0, tiles[1].y);
-            Assert.Equal(1, tiles[2].x);
-            Assert.Equal(1, tiles[2].y);
+            Assert.Equal(0, tiles[0].X);
+            Assert.Equal(0, tiles[0].Y);
+            Assert.Equal(1, tiles[1].X);
+            Assert.Equal(0, tiles[1].Y);
+            Assert.Equal(1, tiles[2].X);
+            Assert.Equal(1, tiles[2].Y);
         }
         
         [Fact]
@@ -74,12 +74,12 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
             var tiles = Shared.LineBetween(0.5, 0.9,1.1, 1.9).ToList();
             
             Assert.Equal(3, tiles.Count);
-            Assert.Equal(0, tiles[0].x);
-            Assert.Equal(0, tiles[0].y);
-            Assert.Equal(0, tiles[1].x);
-            Assert.Equal(1, tiles[1].y);
-            Assert.Equal(1, tiles[2].x);
-            Assert.Equal(1, tiles[2].y);
+            Assert.Equal(0, tiles[0].X);
+            Assert.Equal(0, tiles[0].Y);
+            Assert.Equal(0, tiles[1].X);
+            Assert.Equal(1, tiles[1].Y);
+            Assert.Equal(1, tiles[2].X);
+            Assert.Equal(1, tiles[2].Y);
         }
         
         [Fact]
@@ -88,12 +88,12 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
             var tiles = Shared.LineBetween(1.9, 1.1, 0.9, 0.5).ToList();
             
             Assert.Equal(3, tiles.Count);
-            Assert.Equal(1, tiles[0].x);
-            Assert.Equal(1, tiles[0].y);
-            Assert.Equal(1, tiles[1].x);
-            Assert.Equal(0, tiles[1].y);
-            Assert.Equal(0, tiles[2].x);
-            Assert.Equal(0, tiles[2].y);
+            Assert.Equal(1, tiles[0].X);
+            Assert.Equal(1, tiles[0].Y);
+            Assert.Equal(1, tiles[1].X);
+            Assert.Equal(0, tiles[1].Y);
+            Assert.Equal(0, tiles[2].X);
+            Assert.Equal(0, tiles[2].Y);
         }
         
         [Fact]
@@ -102,12 +102,12 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
             var tiles = Shared.LineBetween(1.1, 1.9,0.5, 0.9).ToList();
             
             Assert.Equal(3, tiles.Count);
-            Assert.Equal(1, tiles[0].x);
-            Assert.Equal(1, tiles[0].y);
-            Assert.Equal(0, tiles[1].x);
-            Assert.Equal(1, tiles[1].y);
-            Assert.Equal(0, tiles[2].x);
-            Assert.Equal(0, tiles[2].y);
+            Assert.Equal(1, tiles[0].X);
+            Assert.Equal(1, tiles[0].Y);
+            Assert.Equal(0, tiles[1].X);
+            Assert.Equal(1, tiles[1].Y);
+            Assert.Equal(0, tiles[2].X);
+            Assert.Equal(0, tiles[2].Y);
         }
         
         [Fact]
@@ -116,14 +116,14 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
             var tiles = Shared.LineBetween(0.5, 0.5,2.5, 1.5).ToList();
             
             Assert.Equal(4, tiles.Count);
-            Assert.Equal(0, tiles[0].x);
-            Assert.Equal(0, tiles[0].y);
-            Assert.Equal(1, tiles[1].x);
-            Assert.Equal(0, tiles[1].y);
-            Assert.Equal(1, tiles[2].x);
-            Assert.Equal(1, tiles[2].y);
-            Assert.Equal(2, tiles[3].x);
-            Assert.Equal(1, tiles[3].y);
+            Assert.Equal(0, tiles[0].X);
+            Assert.Equal(0, tiles[0].Y);
+            Assert.Equal(1, tiles[1].X);
+            Assert.Equal(0, tiles[1].Y);
+            Assert.Equal(1, tiles[2].X);
+            Assert.Equal(1, tiles[2].Y);
+            Assert.Equal(2, tiles[3].X);
+            Assert.Equal(1, tiles[3].Y);
         }
         
         [Fact]
@@ -132,14 +132,14 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
             var tiles = Shared.LineBetween(0.5, 0.5,1.5, 2.5).ToList();
             
             Assert.Equal(4, tiles.Count);
-            Assert.Equal(0, tiles[0].x);
-            Assert.Equal(0, tiles[0].y);
-            Assert.Equal(0, tiles[1].x);
-            Assert.Equal(1, tiles[1].y);
-            Assert.Equal(1, tiles[2].x);
-            Assert.Equal(1, tiles[2].y);
-            Assert.Equal(1, tiles[3].x);
-            Assert.Equal(2, tiles[3].y);
+            Assert.Equal(0, tiles[0].X);
+            Assert.Equal(0, tiles[0].Y);
+            Assert.Equal(0, tiles[1].X);
+            Assert.Equal(1, tiles[1].Y);
+            Assert.Equal(1, tiles[2].X);
+            Assert.Equal(1, tiles[2].Y);
+            Assert.Equal(1, tiles[3].X);
+            Assert.Equal(2, tiles[3].Y);
         }
         
         [Fact]
@@ -148,14 +148,14 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
             var tiles = Shared.LineBetween(2.5, 1.5, 0.5, 0.5).ToList();
             
             Assert.Equal(4, tiles.Count);
-            Assert.Equal(2, tiles[0].x);
-            Assert.Equal(1, tiles[0].y);
-            Assert.Equal(1, tiles[1].x);
-            Assert.Equal(1, tiles[1].y);
-            Assert.Equal(1, tiles[2].x);
-            Assert.Equal(0, tiles[2].y);
-            Assert.Equal(0, tiles[3].x);
-            Assert.Equal(0, tiles[3].y);
+            Assert.Equal(2, tiles[0].X);
+            Assert.Equal(1, tiles[0].Y);
+            Assert.Equal(1, tiles[1].X);
+            Assert.Equal(1, tiles[1].Y);
+            Assert.Equal(1, tiles[2].X);
+            Assert.Equal(0, tiles[2].Y);
+            Assert.Equal(0, tiles[3].X);
+            Assert.Equal(0, tiles[3].Y);
         }
         
         [Fact]
@@ -164,14 +164,14 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
             var tiles = Shared.LineBetween(1.5, 2.5, 0.5, 0.5).ToList();
             
             Assert.Equal(4, tiles.Count);
-            Assert.Equal(1, tiles[0].x);
-            Assert.Equal(2, tiles[0].y);
-            Assert.Equal(1, tiles[1].x);
-            Assert.Equal(1, tiles[1].y);
-            Assert.Equal(0, tiles[2].x);
-            Assert.Equal(1, tiles[2].y);
-            Assert.Equal(0, tiles[3].x);
-            Assert.Equal(0, tiles[3].y);
+            Assert.Equal(1, tiles[0].X);
+            Assert.Equal(2, tiles[0].Y);
+            Assert.Equal(1, tiles[1].X);
+            Assert.Equal(1, tiles[1].Y);
+            Assert.Equal(0, tiles[2].X);
+            Assert.Equal(1, tiles[2].Y);
+            Assert.Equal(0, tiles[3].X);
+            Assert.Equal(0, tiles[3].Y);
         }
         
         [Fact]
@@ -180,18 +180,18 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
             var tiles = Shared.LineBetween(0.5, 0.5,4.5, 1.5).ToList();
             
             Assert.Equal(6, tiles.Count);
-            Assert.Equal(0, tiles[0].x);
-            Assert.Equal(0, tiles[0].y);
-            Assert.Equal(1, tiles[1].x);
-            Assert.Equal(0, tiles[1].y);
-            Assert.Equal(2, tiles[2].x);
-            Assert.Equal(0, tiles[2].y);
-            Assert.Equal(2, tiles[3].x);
-            Assert.Equal(1, tiles[3].y);
-            Assert.Equal(3, tiles[4].x);
-            Assert.Equal(1, tiles[4].y);
-            Assert.Equal(4, tiles[5].x);
-            Assert.Equal(1, tiles[5].y);
+            Assert.Equal(0, tiles[0].X);
+            Assert.Equal(0, tiles[0].Y);
+            Assert.Equal(1, tiles[1].X);
+            Assert.Equal(0, tiles[1].Y);
+            Assert.Equal(2, tiles[2].X);
+            Assert.Equal(0, tiles[2].Y);
+            Assert.Equal(2, tiles[3].X);
+            Assert.Equal(1, tiles[3].Y);
+            Assert.Equal(3, tiles[4].X);
+            Assert.Equal(1, tiles[4].Y);
+            Assert.Equal(4, tiles[5].X);
+            Assert.Equal(1, tiles[5].Y);
         }
         
         [Fact]
@@ -200,18 +200,18 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
             var tiles = Shared.LineBetween(0.5, 0.5,1.5, 4.5).ToList();
             
             Assert.Equal(6, tiles.Count);
-            Assert.Equal(0, tiles[0].x);
-            Assert.Equal(0, tiles[0].y);
-            Assert.Equal(0, tiles[1].x);
-            Assert.Equal(1, tiles[1].y);
-            Assert.Equal(0, tiles[2].x);
-            Assert.Equal(2, tiles[2].y);
-            Assert.Equal(1, tiles[3].x);
-            Assert.Equal(2, tiles[3].y);
-            Assert.Equal(1, tiles[4].x);
-            Assert.Equal(3, tiles[4].y);
-            Assert.Equal(1, tiles[5].x);
-            Assert.Equal(4, tiles[5].y);
+            Assert.Equal(0, tiles[0].X);
+            Assert.Equal(0, tiles[0].Y);
+            Assert.Equal(0, tiles[1].X);
+            Assert.Equal(1, tiles[1].Y);
+            Assert.Equal(0, tiles[2].X);
+            Assert.Equal(2, tiles[2].Y);
+            Assert.Equal(1, tiles[3].X);
+            Assert.Equal(2, tiles[3].Y);
+            Assert.Equal(1, tiles[4].X);
+            Assert.Equal(3, tiles[4].Y);
+            Assert.Equal(1, tiles[5].X);
+            Assert.Equal(4, tiles[5].Y);
         }
         
         [Fact]
@@ -220,18 +220,18 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
             var tiles = Shared.LineBetween(4.5, 1.5, 0.5, 0.5).ToList();
             
             Assert.Equal(6, tiles.Count);
-            Assert.Equal(4, tiles[0].x);
-            Assert.Equal(1, tiles[0].y);
-            Assert.Equal(3, tiles[1].x);
-            Assert.Equal(1, tiles[1].y);
-            Assert.Equal(2, tiles[2].x);
-            Assert.Equal(1, tiles[2].y);
-            Assert.Equal(2, tiles[3].x);
-            Assert.Equal(0, tiles[3].y);
-            Assert.Equal(1, tiles[4].x);
-            Assert.Equal(0, tiles[4].y);
-            Assert.Equal(0, tiles[5].x);
-            Assert.Equal(0, tiles[5].y);
+            Assert.Equal(4, tiles[0].X);
+            Assert.Equal(1, tiles[0].Y);
+            Assert.Equal(3, tiles[1].X);
+            Assert.Equal(1, tiles[1].Y);
+            Assert.Equal(2, tiles[2].X);
+            Assert.Equal(1, tiles[2].Y);
+            Assert.Equal(2, tiles[3].X);
+            Assert.Equal(0, tiles[3].Y);
+            Assert.Equal(1, tiles[4].X);
+            Assert.Equal(0, tiles[4].Y);
+            Assert.Equal(0, tiles[5].X);
+            Assert.Equal(0, tiles[5].Y);
         }
         
         [Fact]
@@ -240,18 +240,18 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
             var tiles = Shared.LineBetween(1.5, 4.5, 0.5, 0.5).ToList();
             
             Assert.Equal(6, tiles.Count);
-            Assert.Equal(1, tiles[0].x);
-            Assert.Equal(4, tiles[0].y);
-            Assert.Equal(1, tiles[1].x);
-            Assert.Equal(3, tiles[1].y);
-            Assert.Equal(1, tiles[2].x);
-            Assert.Equal(2, tiles[2].y);
-            Assert.Equal(0, tiles[3].x);
-            Assert.Equal(2, tiles[3].y);
-            Assert.Equal(0, tiles[4].x);
-            Assert.Equal(1, tiles[4].y);
-            Assert.Equal(0, tiles[5].x);
-            Assert.Equal(0, tiles[5].y);
+            Assert.Equal(1, tiles[0].X);
+            Assert.Equal(4, tiles[0].Y);
+            Assert.Equal(1, tiles[1].X);
+            Assert.Equal(3, tiles[1].Y);
+            Assert.Equal(1, tiles[2].X);
+            Assert.Equal(2, tiles[2].Y);
+            Assert.Equal(0, tiles[3].X);
+            Assert.Equal(2, tiles[3].Y);
+            Assert.Equal(0, tiles[4].X);
+            Assert.Equal(1, tiles[4].Y);
+            Assert.Equal(0, tiles[5].X);
+            Assert.Equal(0, tiles[5].Y);
         }
         
         [Fact]
@@ -260,16 +260,16 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
             var tiles = Shared.LineBetween(2.75, 0.125, 0.26, 2.29).ToList();
             
             Assert.Equal(5, tiles.Count);
-            Assert.Equal(2, tiles[0].x);
-            Assert.Equal(0, tiles[0].y);
-            Assert.Equal(1, tiles[1].x);
-            Assert.Equal(0, tiles[1].y);
-            Assert.Equal(1, tiles[2].x);
-            Assert.Equal(1, tiles[2].y);
-            Assert.Equal(0, tiles[3].x);
-            Assert.Equal(1, tiles[3].y);
-            Assert.Equal(0, tiles[4].x);
-            Assert.Equal(2, tiles[4].y);
+            Assert.Equal(2, tiles[0].X);
+            Assert.Equal(0, tiles[0].Y);
+            Assert.Equal(1, tiles[1].X);
+            Assert.Equal(0, tiles[1].Y);
+            Assert.Equal(1, tiles[2].X);
+            Assert.Equal(1, tiles[2].Y);
+            Assert.Equal(0, tiles[3].X);
+            Assert.Equal(1, tiles[3].Y);
+            Assert.Equal(0, tiles[4].X);
+            Assert.Equal(2, tiles[4].Y);
         }
         
         [Fact]
@@ -278,16 +278,16 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers
             var tiles = Shared.LineBetween(0.26, 0.125, 2.75, 2.29).ToList();
             
             Assert.Equal(5, tiles.Count);
-            Assert.Equal(0, tiles[0].x);
-            Assert.Equal(0, tiles[0].y);
-            Assert.Equal(1, tiles[1].x);
-            Assert.Equal(0, tiles[1].y);
-            Assert.Equal(1, tiles[2].x);
-            Assert.Equal(1, tiles[2].y);
-            Assert.Equal(2, tiles[3].x);
-            Assert.Equal(1, tiles[3].y);
-            Assert.Equal(2, tiles[4].x);
-            Assert.Equal(2, tiles[4].y);
+            Assert.Equal(0, tiles[0].X);
+            Assert.Equal(0, tiles[0].Y);
+            Assert.Equal(1, tiles[1].X);
+            Assert.Equal(0, tiles[1].Y);
+            Assert.Equal(1, tiles[2].X);
+            Assert.Equal(1, tiles[2].Y);
+            Assert.Equal(2, tiles[3].X);
+            Assert.Equal(1, tiles[3].Y);
+            Assert.Equal(2, tiles[4].X);
+            Assert.Equal(2, tiles[4].Y);
         }
     }
 }


### PR DESCRIPTION
.net5.0, Removes the use of Newtonsoft.Json in favor of System.Text.Json, it also removes the use of Tuples for (X,Y(Z)) Structures and instead uses System.Numerics.Vector which cuts down on the amount of reference parameters (register allocation) at the call site as well as increases performance for mathematical operations associated.